### PR TITLE
Add release packaging script to exclude binaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ __pycache__/
 # OS
 .DS_Store
 Thumbs.db
+*.zip
+

--- a/README.md
+++ b/README.md
@@ -2,3 +2,9 @@
 
 BlenderからGemini 2.5 Flash Image（nano-banana）を叩くアドオン。
 EDIT（単一編集）/ COMPOSE（2枚合成）対応。
+
+## Release
+
+`python build_release.py` を実行すると、Git管理情報や `README.md` を含まない
+ソースのみの `nano_banana.zip` を生成します。バイナリやキャッシュファイルは
+同梱されません。

--- a/build_release.py
+++ b/build_release.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""Build a release zip of the nano_banana add-on without binaries.
+
+The resulting archive contains only the Python source inside the
+``nano_banana`` package. Version control metadata, documentation, and
+compiled artifacts are excluded to keep the distribution clean.
+"""
+
+from __future__ import annotations
+
+import shutil
+import zipfile
+from pathlib import Path
+
+ROOT = Path(__file__).parent
+SRC_DIR = ROOT / "nano_banana"
+OUTPUT_ZIP = ROOT / "nano_banana.zip"
+
+
+def purge_compiled() -> None:
+    """Remove ``__pycache__`` directories and ``*.pyc`` files."""
+    for path in SRC_DIR.rglob("__pycache__"):
+        shutil.rmtree(path)
+    for pyc in SRC_DIR.rglob("*.pyc"):
+        pyc.unlink()
+
+
+def build_zip() -> None:
+    """Create a zip archive containing only sources under ``nano_banana``."""
+    with zipfile.ZipFile(OUTPUT_ZIP, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+        for file in SRC_DIR.rglob("*"):
+            if file.is_dir():
+                continue
+            arcname = file.relative_to(ROOT)
+            zf.write(file, arcname)
+
+
+def main() -> None:
+    purge_compiled()
+    if OUTPUT_ZIP.exists():
+        OUTPUT_ZIP.unlink()
+    build_zip()
+    print(f"Created {OUTPUT_ZIP}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- document release process excluding VCS and binaries
- add script to build a clean release zip
- ignore generated zip artifacts

## Testing
- `python build_release.py`
- `unzip -l nano_banana.zip`
- `find . -name '__pycache__' -o -name '*.pyc'`


------
https://chatgpt.com/codex/tasks/task_e_68b96b035dbc832d99e06a3c57c48ffc