### PR TITLE
Prepare add-on for Blender 4.3 extension

### DIFF
--- a/blender_manifest.toml
+++ b/blender_manifest.toml
@@ -1,0 +1,11 @@
+schema_version = "1.0.0"
+id = "jp.sakaki.nano_banana"
+version = "0.5.0"
+name = "Nano-Banana (Gemini Image) Editor"
+type = "add-on"
+maintainer = "Masamune Sakaki <example@example.com>"
+blender_version_min = "4.3.0"
+license = ["SPDX:MIT"]
+
+[permissions]
+network = "Gemini APIにアクセスするため"

--- a/nano_banana/__init__.py
+++ b/nano_banana/__init__.py
@@ -1,8 +1,8 @@
 bl_info = {
     "name": "Nano-Banana (Gemini 2.5 Flash Image) Editor",
     "author": "あなた",
-    "version": (0, 4, 0),
-    "blender": (4, 0, 0),
+    "version": (0, 5, 0),
+    "blender": (4, 3, 0),
     "location": "Image Editor > Nパネル > Nano-Banana",
     "description": "Gemini 2.5 Flash Image(API)で参照×2+レンダ(最後)を編集。レンダ完了で自動実行/連番保存。ログ強化＆リミッター付",
     "category": "Image",


### PR DESCRIPTION
## Summary
- add Blender 4.3 extension manifest
- update metadata for Blender 4.3 and version 0.5.0
- route add-on writes through `bpy.utils.extension_path_user`

## Testing
- `python -m py_compile nano_banana/__init__.py nano_banana/nano_banana_addon.py nano_banana/i18n.py`
- `blender --command extension build .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba90442170832d95cab607c6997f62