### PR TITLE
docs: clarify addon directory and VS Code path

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,17 @@ EDIT（単一編集）/ COMPOSE（2枚合成）対応。
 `python build_release.py` を実行すると、Git管理情報や `README.md` を含まない
 ソースのみの `nano_banana.zip` を生成します。バイナリやキャッシュファイルは
 同梱されません。
+
+## 開発
+
+作業用のアドオンディレクトリは `nano_banana/` です。VS Code の [Blender Development 拡張機能](https://marketplace.visualstudio.com/items?itemName=JacquesLucke.blender-development) を使う場合は、例えば次のように設定します。
+
+```json
+{
+  "name": "Blender: Start",
+  "type": "blender",
+  "request": "launch",
+  "path": "${workspaceFolder}/nano_banana"
+}
+```
+


### PR DESCRIPTION
## Summary
- document working add-on directory `nano_banana/`
- add VS Code Blender Development snippet with `"path": "${workspaceFolder}/nano_banana"`

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68ba976a9f08832dbd624083d85c769f