### PR TITLE
Add Blender extension manifest for extension packaging

### DIFF
--- a/blender_manifest.toml
+++ b/blender_manifest.toml
@@ -1,0 +1,8 @@
+schema_version = "1.0.0"
+id = "nano-banana"
+version = "0.4.0"
+name = "Nano-Banana (Gemini 2.5 Flash Image) Editor"
+type = "add-on"
+blender_version_min = "4.0.0"
+license = "GPL-3.0-or-later"
+maintainers = ["あなた"]

--- a/build_release.py
+++ b/build_release.py
@@ -16,6 +16,10 @@ ROOT = Path(__file__).parent
 SRC_DIR = ROOT / "nano_banana"
 OUTPUT_ZIP = ROOT / "nano_banana.zip"
 
+# Additional non-binary files that should be packaged alongside the add-on
+# for Blender's extension system (e.g. manifest, icons).
+EXTRA_FILES = [ROOT / "blender_manifest.toml"]
+
 
 def purge_compiled() -> None:
     """Remove ``__pycache__`` directories and ``*.pyc`` files."""
@@ -26,13 +30,17 @@ def purge_compiled() -> None:
 
 
 def build_zip() -> None:
-    """Create a zip archive containing only sources under ``nano_banana``."""
+    """Create a zip archive containing the add-on and extension metadata."""
     with zipfile.ZipFile(OUTPUT_ZIP, "w", compression=zipfile.ZIP_DEFLATED) as zf:
         for file in SRC_DIR.rglob("*"):
             if file.is_dir():
                 continue
             arcname = file.relative_to(ROOT)
             zf.write(file, arcname)
+
+        for extra in EXTRA_FILES:
+            if extra.exists():
+                zf.write(extra, extra.name)
 
 
 def main() -> None:


### PR DESCRIPTION
## Summary
- add `blender_manifest.toml` to provide extension metadata
- package manifest in release zip so Blender can load the add-on as an extension

## Testing
- `python -m py_compile build_release.py nano_banana/__init__.py`
- `python build_release.py`
- `unzip -l nano_banana.zip`

------
https://chatgpt.com/codex/tasks/task_e_68ba9e748508832d8ad507914fb905e1