### PR TITLE
Add Blender manifest and update addon metadata

### DIFF
--- a/nano_banana/__init__.py
+++ b/nano_banana/__init__.py
@@ -1,21 +1,20 @@
+# __init__.py
+# ref: __init__ エントリ構成は FreePencil2 を参照 :contentReference[oaicite:1]{index=1}
 bl_info = {
     "name": "Nano-Banana (Gemini 2.5 Flash Image) Editor",
     "author": "あなた",
-    "version": (0, 4, 0),
-    "blender": (4, 0, 0),
+    "version": (0, 5, 0),
+    "blender": (4, 3, 0),
     "location": "Image Editor > Nパネル > Nano-Banana",
     "description": "Gemini 2.5 Flash Image(API)で参照×2+レンダ(最後)を編集。レンダ完了で自動実行/連番保存。ログ強化＆リミッター付",
     "category": "Image",
 }
-
-from .nano_banana_addon import register as _r, unregister as _u
 from . import i18n
-
+from .nano_banana_addon import register as _r, unregister as _u
 
 def register():
     i18n.register()
     _r()
-
 
 def unregister():
     _u()

--- a/nano_banana/blender_manifest.toml
+++ b/nano_banana/blender_manifest.toml
@@ -1,0 +1,11 @@
+# blender_manifest.toml
+# ref: FreePencil2 manifest を参照 :contentReference[oaicite:0]{index=0}
+schema_version = "1.1.0"
+id = "nano_banana"
+version = "0.5.0"
+name = "Nano-Banana (Gemini Image) Editor"
+type = "add-on"
+blender_version_min = "4.3.0"
+license = ["MIT"]
+permissions = ["network"]
+

--- a/nano_banana/nano_banana_addon.py
+++ b/nano_banana/nano_banana_addon.py
@@ -1,3 +1,4 @@
+# ref: README の注意点により bl_info は __init__.py のみに置く想定 :contentReference[oaicite:2]{index=2}
 import bpy, os, json, base64, datetime
 from urllib.request import Request, urlopen
 from urllib.error import URLError, HTTPError
@@ -15,11 +16,11 @@ _NB_HANDLER_REGISTERED = False  # render_write ハンドラ重複登録防止
 # =========================================================
 # Add-on Preferences
 # =========================================================
-ADDON_NAME = __package__ if __package__ else __name__
+ADDON_NAME = "nano_banana"
 
 
 class NBPreferences(AddonPreferences):
-    bl_idname = ADDON_NAME
+    bl_idname = "nano_banana"
     api_key: StringProperty(
         name="Gemini API Key",
         description="Google AI StudioのAPIキー",


### PR DESCRIPTION
## Summary
- add Blender manifest with metadata and network permission
- update add-on info to version 0.5.0 for Blender 4.3
- fix add-on name references to static `nano_banana`

## Testing
- `python -m py_compile nano_banana/__init__.py nano_banana/nano_banana_addon.py nano_banana/i18n.py`
- `python build_release.py`

------
https://chatgpt.com/codex/tasks/task_e_68bab1c441a8832d8d3fa6540aa321d6