### PR TITLE
Add Blender manifest and clarify nano_banana installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,12 @@
 BlenderからGemini 2.5 Flash Image（nano-banana）を叩くアドオン。
 EDIT（単一編集）/ COMPOSE（2枚合成）対応。
 
+## インストール
+
+Blender の拡張機能ディレクトリに配置する際は、このリポジトリのルートフォルダ
+`nano-banana-blender-addon` を `nano_banana` にリネームしてからコピーします。
+フォルダ直下には `__init__.py` と `blender_manifest.toml` が存在する必要があります。
+
 ## Release
 
 `python build_release.py` を実行すると、Git管理情報や `README.md` を含まない

--- a/nano_banana/blender_manifest.toml
+++ b/nano_banana/blender_manifest.toml
@@ -1,0 +1,10 @@
+schema_version = "1.0.0"
+
+id = "nano_banana"
+version = "0.4.0"
+name = "Nano-Banana (Gemini 2.5 Flash Image) Editor"
+tagline = "Gemini 2.5 Flash Image add-on"
+maintainer = "あなた"
+type = "add-on"
+blender_version_min = "4.0.0"
+license = "GPL-3.0-or-later"


### PR DESCRIPTION
## Summary
- include a `blender_manifest.toml` so the `nano_banana` folder can be installed directly as a Blender add-on
- document that the repository root should be renamed to `nano_banana` before copying to Blender's extension path

## Testing
- `python build_release.py`
- `unzip -l nano_banana.zip`

------
https://chatgpt.com/codex/tasks/task_e_68babfe4b438832da62ae4b73a032b9c