### PR TITLE
Add AI Studio API key page shortcut

### DIFF
--- a/nano_banana/i18n.py
+++ b/nano_banana/i18n.py
@@ -5,6 +5,7 @@ I18N_DICT = {
         ("*", "Nano-Banana (Gemini Image)"): "Nano-Banana（Gemini画像）",
         ("*", "Nano-Banana"): "Nano-Banana",
         ("*", "Gemini API Key"): "Gemini APIキー",
+        ("*", "Open API Key Page"): "APIキー取得ページを開く",
         ("*", "Mode"): "モード",
         ("*", "Edit (1 image)"): "編集（1枚）",
         ("*", "Compose (Refs+Render)"): "合成（参照+レンダ）",

--- a/nano_banana/nano_banana_addon.py
+++ b/nano_banana/nano_banana_addon.py
@@ -443,6 +443,7 @@ class NB_PT_Panel(Panel):
         layout = self.layout
 
         layout.prop(p, "api_key")
+        layout.operator("wm.url_open", text=_("Open API Key Page")).url = "https://aistudio.google.com/app/apikey"
         layout.separator()
 
         box = layout.box()


### PR DESCRIPTION
## Summary
- add button to open Google AI Studio API key page in the default browser
- translate new button label into Japanese

## Testing
- `python -m py_compile nano_banana/nano_banana_addon.py nano_banana/i18n.py nano_banana/__init__.py`


------
https://chatgpt.com/codex/tasks/task_e_68c3cd2d8994832d980435feffdb4677